### PR TITLE
Fixed some minor issues with Kodi Matrix

### DIFF
--- a/resources/lib/tasks/taskScript.py
+++ b/resources/lib/tasks/taskScript.py
@@ -142,7 +142,6 @@ class TaskScript(AbstractTask):
             args = ' '.join(args)
         err = False
         msg += u'taskScript ARGS = %s\n    SYSEXEC = %s\n BASEDIR = %s\n' % (args, sysexecutable, basedir)
-        sys.exc_clear()
 
         try:
             if basedir is not None:

--- a/resources/lib/utils/detectPath.py
+++ b/resources/lib/utils/detectPath.py
@@ -24,8 +24,7 @@ from resources.lib.utils.kodipathtools import translatepath
 
 def process_cmdline(cmd):
     posspaths = []
-    cmds = cmd.encode('utf-8')
-    partss = shlex.split(cmds, posix= not sys.platform.lower().startswith('win'))
+    partss = shlex.split(cmd, posix= not sys.platform.lower().startswith('win'))
     parts = []
     for part in partss:
         parts.append(str(part))

--- a/script.py
+++ b/script.py
@@ -55,7 +55,7 @@ def test(key):
     settings = Settings()
     settings.getSettings()
     if settings.general['elevate_loglevel'] is True:
-        KodiLogger.setLogLevel(xbmc.LOGNOTICE)
+        KodiLogger.setLogLevel(xbmc.LOGINFO)
     else:
         KodiLogger.setLogLevel(xbmc.LOGDEBUG)
     log(msg=_('Settings for test read'))


### PR DESCRIPTION
Hi @pikim!

Thank you for upgrading this addon. For some reason there were still some minor Python 3 issues with it on my latest Kodi Matrix:
* sys.exc_clear() got obsolete
* xbmc.LOGNOTICE was changed to xbmc.LOGINFO
* shlex.split expects a string and not a byte array as first parameter

Please review and integrate if you like to...

Thank you and best regards,
Sven